### PR TITLE
feat: Enhance interactive queries; Suppress non-data output

### DIFF
--- a/src/firebolt_cli/query.py
+++ b/src/firebolt_cli/query.py
@@ -3,6 +3,7 @@ import os
 import sys
 
 import click
+import sqlparse  # type: ignore
 from click import command, echo, option
 from firebolt.common.exception import FireboltError
 from firebolt.db import Cursor
@@ -22,6 +23,7 @@ from firebolt_cli.utils import (
     construct_resource_manager,
     create_connection,
     exit_on_firebolt_exception,
+    format_short_statement,
     get_default_database_engine,
     read_from_file,
     read_from_stdin_buffer,
@@ -33,28 +35,61 @@ TABLES_COMMAND = ".tables"
 INTERNAL_COMMANDS = EXIT_COMMANDS + HELP_COMMANDS + [TABLES_COMMAND]
 
 
-def print_result_if_any(cursor: Cursor, use_csv: bool) -> None:
+def is_data_statement(statement: sqlparse.sql.Statement) -> bool:
     """
-    Fetch the data from cursor and print it in csv or tabular format
+    true if the statement is supposed to output some data
     """
-    while 1:
-        if cursor.description:
-            data = cursor.fetchall()
+    token = statement.token_first(skip_cm=True, skip_ws=True).normalized
+    return token in {"SHOW", "DESCRIBE", "EXPLAIN", "SELECT", "WITH"}
 
-            headers = [i.name for i in cursor.description]
-            if use_csv:
-                writer = csv.writer(sys.stdout)
-                writer.writerow(headers)
-                writer.writerows(data)
-            else:
-                echo(tabulate(data, headers=headers, tablefmt="grid"))
 
-        if not cursor.nextset():
-            break
+def echo_execution_status(statement: str, success: bool) -> None:
+    """
+    print execution summary result: Success or Error
+    and a shortened statement to which it is referring
+    """
+    statement = format_short_statement(statement)
+    msg, color = ("Success:", "green") if success else ("Error:", "yellow")
+
+    echo("{} {}".format(click.style(msg, fg=color, bold=True), statement))
+
+
+def execute_and_print(cursor: Cursor, query: str, use_csv: bool) -> None:
+    """
+    execute multiple queries one by one, fetch the data from cursor
+    and print it in csv or tabular format
+    """
+    statements = sqlparse.parse(query)
+
+    for statement in statements:
+        try:
+            cursor.execute(str(statement))
+
+            is_data = is_data_statement(statement)
+
+            if not use_csv:
+                echo_execution_status(str(statement), success=True)
+
+            if cursor.description and is_data:
+                data = cursor.fetchall()
+
+                headers = [i.name for i in cursor.description]
+                if use_csv:
+                    writer = csv.writer(sys.stdout)
+                    writer.writerow(headers)
+                    writer.writerows(data)
+                else:
+                    echo(tabulate(data, headers=headers, tablefmt="grid"))
+
+            cursor.nextset()
+
+        except FireboltError as err:
+            echo_execution_status(str(statement), success=False)
+            raise err
 
 
 @Condition
-def is_multilne_needed() -> bool:
+def is_multiline_needed() -> bool:
     """
     function reads the buffer of the interactive prompt
     and return true if the continuation of the request is required
@@ -108,7 +143,7 @@ def enter_interactive_session(cursor: Cursor, use_csv: bool) -> None:
         message="firebolt> ",
         prompt_continuation="     ...> ",
         lexer=PygmentsLexer(PostgresLexer),
-        multiline=is_multilne_needed,
+        multiline=is_multiline_needed,
     )
 
     while 1:
@@ -122,8 +157,7 @@ def enter_interactive_session(cursor: Cursor, use_csv: bool) -> None:
             if len(sql_query) == 0:
                 continue
 
-            cursor.execute(sql_query)
-            print_result_if_any(cursor, use_csv=use_csv)
+            execute_and_print(cursor, sql_query, use_csv)
         except FireboltError as err:
             echo(err)
             continue
@@ -184,8 +218,7 @@ def query(**raw_config_options: str) -> None:
 
         if sql_query:
             # if query is available, then execute, print result and exit
-            cursor.execute(sql_query)
-            print_result_if_any(cursor, bool(raw_config_options["csv"]))
+            execute_and_print(cursor, sql_query, bool(raw_config_options["csv"]))
         else:
             # otherwise start the interactive session
             enter_interactive_session(cursor, bool(raw_config_options["csv"]))

--- a/src/firebolt_cli/utils.py
+++ b/src/firebolt_cli/utils.py
@@ -1,11 +1,13 @@
 import json
 import os
+import re
 import sys
 from configparser import ConfigParser
 from functools import wraps
 from typing import Callable, Dict, Optional, Sequence, Tuple, Type
 
 import keyring
+import sqlparse  # type: ignore
 from appdirs import user_config_dir
 from click import Command, Context, Group, echo
 from firebolt.common import Settings
@@ -13,7 +15,7 @@ from firebolt.common.exception import FireboltError
 from firebolt.db.connection import Connection, connect
 from firebolt.model.engine import Engine
 from firebolt.service.manager import ResourceManager
-from firebolt_ingest.aws_settings import (  # type: ignore
+from firebolt_ingest.aws_settings import (
     AWSCredentials,
     AWSCredentialsKeySecret,
     AWSCredentialsRole,
@@ -44,6 +46,32 @@ def construct_shortcuts(shortages: dict) -> Type[Group]:
             return Group.get_command(self, ctx, matches[0])
 
     return AliasedGroup
+
+
+def format_short_statement(statement: str, truncate_long_string: int = 80) -> str:
+    """
+    Format a complex query into a single line with
+    stripped comments and excessive whitespaces
+
+    Args:
+        statement: a valid sql statement
+        truncate_long_string: if set to positive integer strings longer, that
+        the specified value will be truncated and "..." will be added
+
+    Returns: a formatted string
+
+    """
+    statement = sqlparse.format(
+        str(statement), strip_comments=True, use_space_around_operators=True
+    )
+
+    statement = statement.replace("\n", " ").replace("\t", " ").strip()
+    statement = re.sub(" +", " ", statement)
+
+    if 0 < truncate_long_string < len(statement):
+        return statement[:truncate_long_string] + " ..."
+
+    return statement
 
 
 def prepare_execution_result_line(

--- a/src/firebolt_cli/utils.py
+++ b/src/firebolt_cli/utils.py
@@ -66,6 +66,8 @@ def format_short_statement(statement: str, truncate_long_string: int = 80) -> st
     )
 
     statement = statement.replace("\n", " ").replace("\t", " ").strip()
+
+    # strip consecutive whitespaces
     statement = re.sub(" +", " ", statement)
 
     if 0 < truncate_long_string < len(statement):

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -117,8 +117,8 @@ def test_query_csv_output(
     query_generic_test(
         ["--csv", "--engine-name", "engine-name"],
         check_csv_correctness,
-        expected_sql="query from input;",
-        input="query from input;",
+        expected_sql="SELECT 1;",
+        input="SELECT 1;",
         cursor_mock=cursor_mock,
     )
 
@@ -244,19 +244,21 @@ def test_sql_execution_multiline(
         header_mock.name = header_name
 
     cursor_mock.description = headers
-    expected_sql = "SELECT * FROM t1; SELECT * FROM t2"
 
     result = CliRunner().invoke(
         query,
         "--engine-name engine-name".split(),
-        input=expected_sql,
+        input="SELECT * FROM t1;SELECT * FROM t2;",
     )
     assert result.exit_code == 0
 
     assert cursor_mock.nextset.call_count == 2
     assert cursor_mock.fetchall.call_count == 2
 
-    cursor_mock.execute.assert_called_once_with(expected_sql)
+    cursor_mock.execute.assert_has_calls(
+        [mock.call("SELECT * FROM t1;"), mock.call("SELECT * FROM t2;")]
+    )
+    assert cursor_mock.execute.call_count == 2
 
 
 def test_query_default_engine(

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -255,10 +255,10 @@ def test_sql_execution_multiline(
     assert cursor_mock.nextset.call_count == 2
     assert cursor_mock.fetchall.call_count == 2
 
-    cursor_mock.execute.assert_has_calls(
-        [mock.call("SELECT * FROM t1;"), mock.call("SELECT * FROM t2;")]
-    )
-    assert cursor_mock.execute.call_count == 2
+    assert cursor_mock.execute.mock_calls == [
+        mock.call("SELECT * FROM t1;"),
+        mock.call("SELECT * FROM t2;"),
+    ]
 
 
 def test_query_default_engine(

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -18,6 +18,7 @@ from firebolt_cli.utils import (
     convert_bytes,
     create_aws_creds_from_environ,
     create_connection,
+    format_short_statement,
     get_default_database_engine,
     prepare_execution_result_line,
     prepare_execution_result_table,
@@ -426,3 +427,17 @@ def test_create_aws_creds_from_environ_invalide():
     ):
         with pytest.raises(FireboltError):
             create_aws_creds_from_environ()
+
+
+def test_format_short_statement():
+    """
+    test common cases of format_short_statement
+    """
+    assert format_short_statement("SELECT 1") == "SELECT 1"
+    assert format_short_statement("/**/ SELECT 1") == "SELECT 1"
+    assert format_short_statement("-- SELECT 1;\nSELECT 2") == "SELECT 2"
+    assert (
+        format_short_statement("SELECT        23          \n FROM table\n")
+        == "SELECT 23 FROM table"
+    )
+    assert format_short_statement("SELECT 123", truncate_long_string=6) == "SELECT ..."

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -429,15 +429,24 @@ def test_create_aws_creds_from_environ_invalide():
             create_aws_creds_from_environ()
 
 
-def test_format_short_statement():
+@pytest.mark.parametrize(
+    "argument, expected",
+    [
+        ("SELECT 1", "SELECT 1"),
+        ("/**/ SELECT 1", "SELECT 1"),
+        ("-- SELECT 1;\nSELECT 2", "SELECT 2"),
+        ("SELECT        23          \n FROM table\n", "SELECT 23 FROM table"),
+    ],
+)
+def test_format_short_statement(argument: str, expected: str):
     """
     test common cases of format_short_statement
     """
-    assert format_short_statement("SELECT 1") == "SELECT 1"
-    assert format_short_statement("/**/ SELECT 1") == "SELECT 1"
-    assert format_short_statement("-- SELECT 1;\nSELECT 2") == "SELECT 2"
-    assert (
-        format_short_statement("SELECT        23          \n FROM table\n")
-        == "SELECT 23 FROM table"
-    )
+    assert format_short_statement(argument) == expected
+
+
+def test_format_short_statement_truncate():
+    """
+    test format_short_statement with truncate_long_string paramter
+    """
     assert format_short_statement("SELECT 123", truncate_long_string=6) == "SELECT ..."


### PR DESCRIPTION
The most major enhancement is seen in the screenshot:
- Print the execution result of the query (Error/Success).
- Print output information only from queries, when data is expected.
- In case of multiple queries, print the result of queries until we encounter error. 

<img width="670" alt="Screenshot 2022-04-27 at 10 55 17" src="https://user-images.githubusercontent.com/97026256/165469641-48dba23f-9ea0-4ab5-becb-18c9ecb2231f.png">
