### PR TITLE
test: Change to us-east-1 region

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
     hooks:
       - id: black_nbconvert
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 3.7.9
     hooks:
       - id: flake8

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -28,7 +28,7 @@ def must_env(var_name: str) -> str:
 
 @fixture(scope="session")
 def default_region() -> str:
-    return "eu-west-1"
+    return "us-east-1"
 
 
 @fixture(scope="session")


### PR DESCRIPTION
Since Firenze has been deployed there's one account per region policy. It no longer makes sense to test non-default region db creation so I'm switching region to `us-east-1`, for which account we're using is enabled.