### PR TITLE
lock sdk version to use 0.x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     appdirs==1.4.4
     click>=8.1.2
     firebolt-ingest>=0.3.0
-    firebolt-sdk>=0.9.2
+    firebolt-sdk>=0.9.2,<1.0.0
     keyring>=23.5.0
     prompt-toolkit>=3.0.29
     tabulate>=0.8.9


### PR DESCRIPTION
Lock python sdk version to only use 0.x versions