### PR TITLE
ci: Use 0.x tests for 0.x release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   integration-tests:
-    uses: firebolt-db/firebolt-cli/.github/workflows/integration-tests.yml
+    uses: firebolt-db/firebolt-cli/.github/workflows/integration-tests.yml@0.x
     secrets: inherit
 
   publish:
@@ -38,4 +38,4 @@ jobs:
   
   docker-push:
     needs: publish
-    uses: firebolt-db/firebolt-cli/.github/workflows/docker-build.yml
+    uses: firebolt-db/firebolt-cli/.github/workflows/docker-build.yml@0.x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   integration-tests:
-    uses: firebolt-db/firebolt-cli/.github/workflows/integration-tests.yml@main
+    uses: firebolt-db/firebolt-cli/.github/workflows/integration-tests.yml
     secrets: inherit
 
   publish:
@@ -38,4 +38,4 @@ jobs:
   
   docker-push:
     needs: publish
-    uses: firebolt-db/firebolt-cli/.github/workflows/docker-build.yml@main
+    uses: firebolt-db/firebolt-cli/.github/workflows/docker-build.yml


### PR DESCRIPTION
Use 0.x version of integration tests when releasing from 0.x branch