### PR TITLE
ci: Set correct main branch value in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
         pypi-username: ${{ secrets.PYPI_USERNAME }}
         pypi-password: ${{ secrets.PYPI_PASSWORD }}
         version-file-path: "src/firebolt_cli/__init__.py"
+        main-branch: 0.x
   
   docker-push:
     needs: publish


### PR DESCRIPTION
Publish action fails because main branch was set to default, setting it specifically to 0.x